### PR TITLE
First image port to UBI 8

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,4 @@
+defaultBaseImage: registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 baseImageOverrides:
   # TODO(christiewilson): Use our built base image
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/knative-nightly/github.com/knative/build/build-base:latest

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,3 @@
-defaultBaseImage: registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 baseImageOverrides:
   # TODO(christiewilson): Use our built base image
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/knative-nightly/github.com/knative/build/build-base:latest

--- a/openshift/ci-operator/Dockerfile-git.in
+++ b/openshift/ci-operator/Dockerfile-git.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 RUN yum install -y git openssh-client
 

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD ${bin} /ko-app/${bin}
 ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/knative-images/bash/Dockerfile
+++ b/openshift/ci-operator/knative-images/bash/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD bash /ko-app/bash
 ENTRYPOINT ["/ko-app/bash"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD controller /ko-app/controller
 ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/creds-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/creds-init/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 RUN yum install -y git openssh-client
 

--- a/openshift/ci-operator/knative-images/entrypoint/Dockerfile
+++ b/openshift/ci-operator/knative-images/entrypoint/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD entrypoint /ko-app/entrypoint
 ENTRYPOINT ["/ko-app/entrypoint"]

--- a/openshift/ci-operator/knative-images/git-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/git-init/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 RUN yum install -y git openssh-client
 

--- a/openshift/ci-operator/knative-images/gsutil/Dockerfile
+++ b/openshift/ci-operator/knative-images/gsutil/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD gsutil /ko-app/gsutil
 ENTRYPOINT ["/ko-app/gsutil"]

--- a/openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
+++ b/openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD kubeconfigwriter /ko-app/kubeconfigwriter
 ENTRYPOINT ["/ko-app/kubeconfigwriter"]

--- a/openshift/ci-operator/knative-images/nop/Dockerfile
+++ b/openshift/ci-operator/knative-images/nop/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD nop /ko-app/nop
 ENTRYPOINT ["/ko-app/nop"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD webhook /ko-app/webhook
 ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -65,7 +65,7 @@ function create_test_namespace() {
 
 function run_go_e2e_tests() {
   header "Running Go e2e tests"
-  go_test_e2e -ldflags '-X github.com/tektoncd/pipeline/test.missingKoFatal=false' ./test -timeout=20m --kubeconfig $KUBECONFIG || return 1
+  go test -count=1 -tags=e2e -ldflags '-X github.com/tektoncd/pipeline/test.missingKoFatal=false' ./test -timeout=20m --kubeconfig $KUBECONFIG || return 1
 }
 
 function run_yaml_e2e_tests() {

--- a/tekton/ko/Dockerfile
+++ b/tekton/ko/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
+FROM google/cloud-sdk:latest
 
 # Install golang
 RUN curl https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz > go1.12.1.tar.gz

--- a/tekton/ko/Dockerfile
+++ b/tekton/ko/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:latest
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 # Install golang
 RUN curl https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz > go1.12.1.tar.gz


### PR DESCRIPTION
After this PR the base image used will be UBI 8 for
- github.com/tektoncd/pipeline/cmd/nop,
- github.com/tektoncd/pipeline/cmd/kubeconfigwriter,
- github.com/tektoncd/pipeline/cmd/webhook,
- github.com/tektoncd/pipeline/cmd/controller

This PR is related to https://jira.coreos.com/browse/SRVKP-30