### PR TITLE
Resolves - https://jira.coreos.com/browse/SRVKP-30

### DIFF
--- a/openshift/ci-operator/Dockerfile-git.in
+++ b/openshift/ci-operator/Dockerfile-git.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 # NOTE(chmou): We use dollar here so that envsubst don't get confused and expand
 # our local PATH.

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD ${bin} /ko-app/${bin}
 ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/knative-images/bash/Dockerfile
+++ b/openshift/ci-operator/knative-images/bash/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD bash /ko-app/bash
 ENTRYPOINT ["/ko-app/bash"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD controller /ko-app/controller
 ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/creds-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/creds-init/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 # NOTE(chmou): We use dollar here so that envsubst don't get confused and expand
 # our local PATH.

--- a/openshift/ci-operator/knative-images/entrypoint/Dockerfile
+++ b/openshift/ci-operator/knative-images/entrypoint/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD entrypoint /ko-app/entrypoint
 ENTRYPOINT ["/ko-app/entrypoint"]

--- a/openshift/ci-operator/knative-images/git-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/git-init/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 # NOTE(chmou): We use dollar here so that envsubst don't get confused and expand
 # our local PATH.

--- a/openshift/ci-operator/knative-images/gsutil/Dockerfile
+++ b/openshift/ci-operator/knative-images/gsutil/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD gsutil /ko-app/gsutil
 ENTRYPOINT ["/ko-app/gsutil"]

--- a/openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
+++ b/openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD kubeconfigwriter /ko-app/kubeconfigwriter
 ENTRYPOINT ["/ko-app/kubeconfigwriter"]

--- a/openshift/ci-operator/knative-images/nop/Dockerfile
+++ b/openshift/ci-operator/knative-images/nop/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD nop /ko-app/nop
 ENTRYPOINT ["/ko-app/nop"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.access.redhat.com/ubi8-dev-preview/ubi:latest
 
 ADD webhook /ko-app/webhook
 ENTRYPOINT ["/ko-app/webhook"]


### PR DESCRIPTION
Base image changed to UBI-8 for
- openshift/ci-operator/Dockerfile-git.in
- openshift/ci-operator/Dockerfile.in
- openshift/ci-operator/knative-images/bash/Dockerfile
- openshift/ci-operator/knative-images/controller/Dockerfile
- openshift/ci-operator/knative-images/creds-init/Dockerfile
- openshift/ci-operator/knative-images/entrypoint/Dockerfile
- openshift/ci-operator/knative-images/git-init/Dockerfile
- openshift/ci-operator/knative-images/gsutil/Dockerfile
- openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
- openshift/ci-operator/knative-images/nop/Dockerfile
- openshift/ci-operator/knative-images/webhook/Dockerfile