### PR TITLE
generate-dockerfiles before doing a make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ GOOS=linux
 CORE_IMAGES=./cmd/bash ./cmd/controller ./cmd/entrypoint ./cmd/gsutil ./cmd/kubeconfigwriter ./cmd/nop ./cmd/webhook
 CORE_IMAGES_WITH_GIT=./cmd/creds-init ./cmd/git-init
 
+# NOTE(chmou): Install an uidwraper for launching some binaries with fixed uid
+UIDWRAPPER_PATH=./openshift/ci-operator/uidwrapper
+
 # Install core images
-install: installuidwrapper
+install: generate-dockerfiles installuidwrapper
 	go install $(CORE_IMAGES) $(CORE_IMAGES_WITH_GIT)
 .PHONY: install
 
@@ -21,7 +24,6 @@ generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile-git.in openshift/ci-operator/knative-images $(CORE_IMAGES_WITH_GIT)
 .PHONY: generate-dockerfiles
 
-# NOTE(chmou): Install uidwraper for launching some binaries with fixed uid
-UIDWRAPPER_PATH=./openshift/ci-operator/uidwrapper
 installuidwrapper: $(UIDWRAPPER_PATH)
 	install -m755 $(UIDWRAPPER_PATH) $(GOPATH)/bin/
+.PHONY: installuidwrapper


### PR DESCRIPTION
We probably would not need to add the generate dockerfiles to the repo too, but
let's keep it as is for now

Ref: https://jira.coreos.com/browse/SRVKP-120?filter=-1