### PR TITLE
Update e2e script to mirror upstream changes

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 
 set -x
 


### PR DESCRIPTION
Upstream recently migrated its scripts from knative/test-infra to
tektoncd/plumbing, so we need this change to build master again 👼

Should fix https://github.com/openshift/tektoncd-pipeline/pull/30 automatic builds :angel: 

/cc @chmouel 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>