### PR TITLE
Adds metrics configuration to pipeline

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -6,6 +6,8 @@
 
 * You need to make sure to have your remote properly setup, one called `upstream` against [tektoncd/pipeline](https://github.com/tektoncd/pipeline) and one called `openshift` against [openshift/tektoncd-pipeline](https://github.com/openshift/tektoncd-pipeline)
 
+* `yq` [CLI tool is installed](https://mikefarah.github.io/yq/)
+
 ## Steps
 
 * Generate a new branch and push it to <https://github.com/openshift/tektoncd-pipeline> with this [script](https://github.com/openshift/tektoncd-pipeline/blob/master/openshift/release/create-release-branch.sh), for example like this :

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -14,3 +14,4 @@ else
 fi
 
 resolve_resources config/ $output_file noignore $image_prefix $tag
+yq w -d'*' -i $output_file "metadata.labels[openshift.io/cluster-monitoring]" "true"


### PR DESCRIPTION
In order to eanble scraping for `/metrics` endpoint,a clusterwide
prometheus expects to have `openshift.io/cluster-monitoring`
lable on pipeline namespace.

This patch adds the `openshift.io/cluster-monitoring` lable
on pipeline namespace while generating `release.yaml`

fixes https://jira.coreos.com/browse/SRVKP-298