### PR TITLE
Update base image of nop Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+#This makefile is used by ci-operator
+
+CGO_ENABLED=0
+GOOS=linux
+CORE_IMAGES=./cmd/bash ./cmd/controller ./cmd/entrypoint ./cmd/gsutil ./cmd/kubeconfigwriter ./cmd/nop ./cmd/webhook ./cmd/imagedigestexporter ./cmd/pullrequest-init
+CORE_IMAGES_WITH_GIT=./cmd/creds-init ./cmd/git-init
+
+##
+# You need to provide a RELEASE_VERSION when using targets like `push-image`, you can do it directly
+# on the command like this: `make push-image RELEASE_VERSION=0.4.0`
+RELEASE_VERSION=
+REGISTRY_CI_URL=registry.svc.ci.openshift.org/openshift/tektoncd-v$(RELEASE_VERSION):tektoncd-pipeline
+REGISTRY_RELEASE_URL=quay.io/openshift-pipeline/tektoncd-pipeline
+
+# Install core images
+install: installuidwrapper
+	go install $(CORE_IMAGES) $(CORE_IMAGES_WITH_GIT)
+.PHONY: install
+
+# Run E2E tests on OpenShift
+test-e2e: check-images
+	./openshift/e2e-tests-openshift.sh
+.PHONY: test-e2e
+
+# Make sure we have all images in the makefile variable or that would be a new
+# binary that needs to be added
+check-images:
+	@for cmd in ./cmd/*;do \
+		found="" ;\
+		for image in $(CORE_IMAGES) $(CORE_IMAGES_WITH_GIT);do \
+			if [[ $$image == $$cmd ]];then \
+				found=1 ;\
+			fi \
+		done ;\
+		test -n $$found || { \
+			echo "*ERROR*: Could not find $$cmd in the Makefile variables CORE_IMAGES_WITH_GIT CORE_IMAGES" ;\
+			echo "" ;\
+			echo "If it it's a new binary that was added upstream, then do the following :" ;\
+			echo "- Add the binary to openshift/release like this: https://git.io/fj18c" ;\
+			echo "- Add to the CORE_IMAGES variables in the Makefile" ;\
+			echo "- Generate the dockerfiles by running 'make generate-dockerfiles'" ;\
+			echo "- Commit and PR these to 'openshift/release-next' remote/branch and 'openshift/master'" ;\
+			exit 1 ;\
+		} && exit 0 ;\
+	done
+.PHONY: check-images
+
+# Generate Dockerfiles used by ci-operator. The files need to be committed manually.
+generate-dockerfiles:
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile.in openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile-git.in openshift/ci-operator/knative-images $(CORE_IMAGES_WITH_GIT)
+.PHONY: generate-dockerfiles
+
+# NOTE(chmou): Install uidwraper for launching some binaries with fixed uid
+UIDWRAPPER_PATH=./openshift/ci-operator/uidwrapper
+installuidwrapper: $(UIDWRAPPER_PATH)
+	install -m755 $(UIDWRAPPER_PATH) $(GOPATH)/bin/
+
+# Generates a ci-operator configuration for a specific branch.
+generate-ci-config:
+	./openshift/ci-operator/generate-ci-config.sh $(BRANCH) > ci-operator-config.yaml
+.PHONY: generate-ci-config
+
+# Generate an aggregated knative yaml file with replaced image references
+generate-release:
+	@test $(RELEASE_VERSION) || { echo "You need to set the RELEASE_VERSION on the command line i.e: make RELEASE_VERSION=0.4.0"; exit ;1;}
+	@./openshift/release/generate-release.sh v$(RELEASE_VERSION)
+.PHONY: generate-release
+
+.PHONY: push-image

--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- bobcatfish
-- dlorenc
-- ImJasonH
-- vdemeester
-- abayer
-- afrittoli
-- dibyom
-- sbwsg
+- build-pipeline-approvers
 
-# Alumni ❤️
-# tejal29
-# pivotal-nader-ziada
-# shashwathi
-# aaron-prindle
+reviewers:
+- build-pipeline-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,24 @@
+aliases:
+  build-pipeline-approvers:
+  - mgencur
+  - bbrowning
+  - jcrossley3
+  - markusthoemmes
+  - vdemeester
+  - arilivigni
+  - chmouel
+  - sthaha
+
+  build-pipeline-reviewers:
+  - mgencur
+  - bbrowning
+  - jcrossley3
+  - markusthoemmes
+  - vdemeester
+  - arilivigni
+  - chmouel
+  - sthaha
+  - nikhil-thomas
+  - hrishin
+  - piyush-garg
+  - pradeepitm12

--- a/openshift/ci-operator/Dockerfile-git.in
+++ b/openshift/ci-operator/Dockerfile-git.in
@@ -1,0 +1,19 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# NOTE(chmou): We use dollar here so that envsubst don't get confused and expand
+# our local PATH.
+ENV HOME=/ko-app PATH=DOLLAR{HOME}:DOLLAR{PATH}
+RUN yum install --disableplugin=subscription-manager -y git openssh-clients
+
+COPY ${bin} DOLLAR{HOME}/${bin}.orig
+COPY uidwrapper DOLLAR{HOME}/${bin}
+
+RUN chgrp -R 0 DOLLAR{HOME} && \
+    chmod -R g=u DOLLAR{HOME} /etc/passwd
+
+ENTRYPOINT ["/ko-app/${bin}"]
+
+# Local Variables:
+# mode: dockerfile
+# End:

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD ${bin} /ko-app/${bin}
+ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,0 +1,11 @@
+# Dockerfile to bootstrap build and test in openshift-ci
+
+FROM openshift/origin-release:golang-1.10
+
+# Add kubernetes repository
+ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
+
+RUN yum install -y kubectl ansible
+
+# Allow runtime users to add entries to /etc/passwd
+RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/kubernetes.repo
+++ b/openshift/ci-operator/build-image/kubernetes.repo
@@ -1,0 +1,7 @@
+[kubernetes]
+name=Kubernetes
+baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -x
+
+function generate_dockefiles() {
+  local dockerfile_in=$1;
+  local target_dir=$2; shift; shift
+  for img in $@; do
+    local image_base=$(basename $img)
+    mkdir -p $target_dir/$image_base
+    bin=$image_base envsubst < $dockerfile_in | sed 's/DOLLAR/$/g'  > $target_dir/$image_base/Dockerfile
+  done
+}
+
+generate_dockefiles $@

--- a/openshift/ci-operator/knative-images/bash/Dockerfile
+++ b/openshift/ci-operator/knative-images/bash/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD bash /ko-app/bash
+ENTRYPOINT ["/ko-app/bash"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD controller /ko-app/controller
+ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/creds-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/creds-init/Dockerfile
@@ -1,0 +1,19 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# NOTE(chmou): We use dollar here so that envsubst don't get confused and expand
+# our local PATH.
+ENV HOME=/ko-app PATH=${HOME}:${PATH}
+RUN yum install --disableplugin=subscription-manager -y git openssh-clients
+
+COPY creds-init ${HOME}/creds-init.orig
+COPY uidwrapper ${HOME}/creds-init
+
+RUN chgrp -R 0 ${HOME} && \
+    chmod -R g=u ${HOME} /etc/passwd
+
+ENTRYPOINT ["/ko-app/creds-init"]
+
+# Local Variables:
+# mode: dockerfile
+# End:

--- a/openshift/ci-operator/knative-images/entrypoint/Dockerfile
+++ b/openshift/ci-operator/knative-images/entrypoint/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD entrypoint /ko-app/entrypoint
+ENTRYPOINT ["/ko-app/entrypoint"]

--- a/openshift/ci-operator/knative-images/git-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/git-init/Dockerfile
@@ -1,0 +1,19 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# NOTE(chmou): We use dollar here so that envsubst don't get confused and expand
+# our local PATH.
+ENV HOME=/ko-app PATH=${HOME}:${PATH}
+RUN yum install --disableplugin=subscription-manager -y git openssh-clients
+
+COPY git-init ${HOME}/git-init.orig
+COPY uidwrapper ${HOME}/git-init
+
+RUN chgrp -R 0 ${HOME} && \
+    chmod -R g=u ${HOME} /etc/passwd
+
+ENTRYPOINT ["/ko-app/git-init"]
+
+# Local Variables:
+# mode: dockerfile
+# End:

--- a/openshift/ci-operator/knative-images/gsutil/Dockerfile
+++ b/openshift/ci-operator/knative-images/gsutil/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD gsutil /ko-app/gsutil
+ENTRYPOINT ["/ko-app/gsutil"]

--- a/openshift/ci-operator/knative-images/imagedigestexporter/Dockerfile
+++ b/openshift/ci-operator/knative-images/imagedigestexporter/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD imagedigestexporter /ko-app/imagedigestexporter
+ENTRYPOINT ["/ko-app/imagedigestexporter"]

--- a/openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
+++ b/openshift/ci-operator/knative-images/kubeconfigwriter/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD kubeconfigwriter /ko-app/kubeconfigwriter
+ENTRYPOINT ["/ko-app/kubeconfigwriter"]

--- a/openshift/ci-operator/knative-images/nop/Dockerfile
+++ b/openshift/ci-operator/knative-images/nop/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD nop /ko-app/nop
+ENTRYPOINT ["/ko-app/nop"]

--- a/openshift/ci-operator/knative-images/nop/Dockerfile
+++ b/openshift/ci-operator/knative-images/nop/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM scratch
 
 ADD nop /ko-app/nop
 ENTRYPOINT ["/ko-app/nop"]

--- a/openshift/ci-operator/knative-images/pullrequest-init/Dockerfile
+++ b/openshift/ci-operator/knative-images/pullrequest-init/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD pullrequest-init /ko-app/pullrequest-init
+ENTRYPOINT ["/ko-app/pullrequest-init"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+ADD webhook /ko-app/webhook
+ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/ci-operator/uidwrapper
+++ b/openshift/ci-operator/uidwrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+  fi
+fi
+
+exec ${0}.orig $@

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -e
+source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
+source $(dirname $0)/resolve-yamls.sh
+
+set -x
+
+readonly API_SERVER=$(oc config view --minify | grep server | awk -F'//' '{print $2}' | awk -F':' '{print $1}')
+readonly OPENSHIFT_REGISTRY="${OPENSHIFT_REGISTRY:-"registry.svc.ci.openshift.org"}"
+readonly TEST_NAMESPACE=tekton-pipeline-tests
+readonly TEST_YAML_NAMESPACE=tekton-pipeline-tests-yaml
+readonly TEKTON_PIPELINE_NAMESPACE=tekton-pipelines
+readonly IGNORES="pipelinerun.yaml|private-taskrun.yaml|taskrun.yaml|gcs-resource-spec-taskrun.yaml"
+readonly KO_DOCKER_REPO=image-registry.openshift-image-registry.svc:5000/tektoncd-pipeline
+# Where the CRD will install the pipelines
+readonly TEKTON_NAMESPACE=tekton-pipelines
+# Variable usually set by openshift CI but generating one if not present when running it locally
+readonly OPENSHIFT_BUILD_NAMESPACE=${OPENSHIFT_BUILD_NAMESPACE:-tektoncd-build-$$}
+# Yaml test skipped due of not being able to run on openshift CI, usually becaus
+# of rights.
+# test-git-volume: `"gitRepo": gitRepo volumes are not allowed to be used]'
+declare -ar SKIP_YAML_TEST=(test-git-volume)
+
+function install_tekton_pipeline() {
+  header "Installing Tekton Pipeline"
+
+  create_pipeline
+
+  wait_until_pods_running $TEKTON_PIPELINE_NAMESPACE || return 1
+
+  header "Tekton Pipeline Installed successfully"
+}
+
+function create_pipeline() {
+  resolve_resources config/ tekton-pipeline-resolved.yaml "nothing" $OPENSHIFT_REGISTRY/$OPENSHIFT_BUILD_NAMESPACE/stable
+  oc apply -f tekton-pipeline-resolved.yaml
+}
+
+function create_test_namespace() {
+  for ns in ${TEKTON_NAMESPACE} ${OPENSHIFT_BUILD_NAMESPACE} ${TEST_YAML_NAMESPACE} ${TEST_NAMESPACE};do
+     oc get project ${ns} >/dev/null 2>/dev/null || oc new-project ${ns}
+  done
+
+  oc policy add-role-to-group system:image-puller system:serviceaccounts:$TEST_YAML_NAMESPACE -n $OPENSHIFT_BUILD_NAMESPACE
+  oc policy add-role-to-group system:image-puller system:serviceaccounts:$TEST_NAMESPACE -n $OPENSHIFT_BUILD_NAMESPACE
+}
+
+function run_go_e2e_tests() {
+  header "Running Go e2e tests"
+  go test -v -failfast -count=1 -tags=e2e -ldflags '-X github.com/tektoncd/pipeline/test.missingKoFatal=false' ./test -timeout=20m --kubeconfig $KUBECONFIG || return 1
+}
+
+function run_yaml_e2e_tests() {
+  header "Running YAML e2e tests"
+  oc project $TEST_YAML_NAMESPACE
+  resolve_resources examples/ tests-resolved.yaml $IGNORES $OPENSHIFT_REGISTRY/$OPENSHIFT_BUILD_NAMESPACE/stable
+  oc apply -f tests-resolved.yaml
+
+  # The rest of this function copied from test/e2e-common.sh#run_yaml_tests()
+  # The only change is "kubectl get builds" -> "oc get builds.build.knative.dev"
+  oc get project
+
+  # Wait for tests to finish.
+  echo ">> Waiting for tests to finish"
+  for test in taskrun pipelinerun; do
+    if validate_run ${test}; then
+      echo "ERROR: tests timed out"
+    fi
+  done
+
+  # Check that tests passed.
+  echo ">> Checking test results"
+  for test in taskrun pipelinerun; do
+    if check_results ${test}; then
+      echo ">> All YAML tests passed"
+      return 0
+    fi
+  done
+
+  # it failed, display logs
+  for test in taskrun pipelinerun; do
+    echo "<< State and Logs for ${test}"
+    output_yaml_test_results ${test}
+    output_pods_logs ${test}
+  done
+  return 1
+}
+
+function validate_run() {
+  local tests_finished=0
+  for i in {1..120}; do
+    local finished="$(kubectl get $1.tekton.dev --output=jsonpath='{.items[*].status.conditions[*].status}')"
+    if [[ ! "$finished" == *"Unknown"* ]]; then
+      tests_finished=1
+      break
+    fi
+    sleep 10
+  done
+
+  return ${tests_finished}
+}
+
+function check_results() {
+  local failed=0
+  results="$(kubectl get $1.tekton.dev --output=jsonpath='{range .items[*]}{.metadata.name}={.status.conditions[*].type}{.status.conditions[*].status}{" "}{end}')"
+  for result in ${results}; do
+    reltestname=${result/=*Succeeded*/}
+    skipit=
+    for skip in ${SKIP_YAML_TEST[@]};do
+        [[ ${reltestname} == ${skip} ]] && skipit=True
+    done
+    [[ -n ${skipit} ]] && {
+        echo "INFO: skipping yaml test ${reltestname}"
+        continue
+    }
+    if [[ ! "${result,,}" == *"=succeededtrue" ]]; then
+      echo "ERROR: test ${result} but should be succeededtrue"
+      kubectl get $1.tekton.dev ${reltestname} -o yaml
+      failed=1
+    fi
+  done
+
+  return ${failed}
+}
+
+function output_yaml_test_results() {
+  # If formatting fails for any reason, use yaml as a fall back.
+  oc get $1.tekton.dev -o=custom-columns-file=${REPO_ROOT_DIR}/test/columns.txt ||
+    oc get $1.tekton.dev -oyaml
+}
+
+function output_pods_logs() {
+  echo ">>> $1"
+  oc get $1.tekton.dev -o yaml
+  local runs=$(kubectl get $1.tekton.dev --output=jsonpath="{.items[*].metadata.name}")
+  set +e
+  for run in ${runs}; do
+    echo ">>>> $1 ${run}"
+    case "$1" in
+    "taskrun")
+      go run ./test/logs/main.go -tr ${run}
+      ;;
+    "pipelinerun")
+      go run ./test/logs/main.go -pr ${run}
+      ;;
+    esac
+  done
+  set -e
+  echo ">>>> Pods"
+  kubectl get pods -o yaml
+}
+
+function delete_build_pipeline_openshift() {
+  echo ">> Bringing down Build"
+  # Make sure that are no residual object in the tekton-pipelines namespace.
+  oc delete --ignore-not-found=true taskrun.tekton.dev --all -n $TEKTON_PIPELINE_NAMESPACE
+  oc delete --ignore-not-found=true pipelinerun.tekton.dev --all -n $TEKTON_PIPELINE_NAMESPACE
+  oc delete --ignore-not-found=true task.tekton.dev --all -n $TEKTON_PIPELINE_NAMESPACE
+  oc delete --ignore-not-found=true clustertask.tekton.dev --all -n $TEKTON_PIPELINE_NAMESPACE
+  oc delete --ignore-not-found=true pipeline.tekton.dev --all -n $TEKTON_PIPELINE_NAMESPACE
+  oc delete --ignore-not-found=true pipelineresources.tekton.dev --all -n $TEKTON_PIPELINE_NAMESPACE
+  oc delete --ignore-not-found=true -f tekton-pipeline-resolved.yaml
+}
+
+function delete_test_resources_openshift() {
+  echo ">> Removing test resources (test/)"
+  oc delete --ignore-not-found=true -f tests-resolved.yaml
+}
+
+function delete_test_namespace() {
+  echo ">> Deleting test namespace $TEST_NAMESPACE"
+  #oc policy remove-role-from-group system:image-puller system:serviceaccounts:$TEST_NAMESPACE -n $OPENSHIFT_BUILD_NAMESPACE
+  #oc delete project $TEST_NAMESPACE
+  oc policy remove-role-from-group system:image-puller system:serviceaccounts:$TEST_YAML_NAMESPACE -n $OPENSHIFT_BUILD_NAMESPACE
+  oc delete project $TEST_YAML_NAMESPACE
+}
+
+function teardown() {
+  delete_test_namespace
+  delete_test_resources_openshift
+  delete_build_pipeline_openshift
+}
+
+create_test_namespace
+
+## If we want to debug the E2E script we don't want to use the images from the
+## CI, let the user do this by herself in the `tekton-pipelines` namespace and
+## use the deployed controller/webhook from there.
+[[ -z ${E2E_DEBUG} ]] && install_tekton_pipeline
+
+failed=0
+
+run_go_e2e_tests || failed=1
+
+run_yaml_e2e_tests || failed=1
+
+((failed)) && dump_cluster_state
+
+teardown
+
+((failed)) && exit 1
+
+success

--- a/openshift/release/README.md
+++ b/openshift/release/README.md
@@ -1,0 +1,35 @@
+# Release creation
+
+## Branching
+
+As far as branching goes, we have two use-cases:
+
+1. Creating a branch based off an upstream release tag.
+2. Having a branch that follow upstream's HEAD and serves as a vehicle for continuous integration.
+
+A prerequisite for both scripts is that your local clone of the repository has a remote "upstream"
+that points to the upstream repository and a remote "openshift" that points to the openshift fork.
+
+Run the scripts from the root of the repository.
+
+### Creating a branch based off an upstream release tag
+
+To create a clean branch from an upstream release tag, use the `create-release-branch.sh` script:
+
+```bash
+$ ./openshift/release/create-release-branch.sh v0.4.1 release-0.4
+```
+
+This will create a new branch "release-0.4" based off the tag "v0.4.1" and add all OpenShift specific
+files that we need to run CI on top of it.
+
+### Updating a branch that follow upstream's HEAD
+
+To update a branch to the latest HEAD of upstream use the `update-to-head.sh` script:
+
+```bash
+$ ./openshift/release/update-to-head.sh release-0.5
+```
+
+That will pull the latest master from upstream, rebase the current fixes on the release-0.5 branch
+on top of it and update the Openshift specific files if necessary.

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Usage: create-release-branch.sh v0.4.1 release-0.4
+
+release=$1
+target=$2
+
+# Fetch the latest tags and checkout a new branch from the wanted tag.
+git fetch upstream --tags
+git checkout -b "$target" "$release"
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
+make generate-dockerfiles
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m "Add openshift specific files."

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+source $(dirname $0)/../resolve-yamls.sh
+
+release=$1
+output_file="openshift/release/tektoncd-pipeline-${release}.yaml"
+
+if [ $release = "ci" ]; then
+    image_prefix="image-registry.openshift-image-registry.svc:5000/tektoncd-pipeline/tektoncd-pipeline-"
+else
+    image_prefix="quay.io/openshift-pipeline/tektoncd-pipeline"
+    tag=$release
+fi
+
+resolve_resources config/ $output_file noignore $image_prefix $tag

--- a/openshift/release/tektoncd-pipeline-v.yaml
+++ b/openshift/release/tektoncd-pipeline-v.yaml
@@ -1,0 +1,888 @@
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-webhook
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    app: tekton-pipelines-webhook
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-admin
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineresources.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineResource
+    plural: pipelineresources
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-aggregate-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: tekton-pipelines
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # default-timeout-minutes contains the default number of
+    # minutes to use for TaskRun and PipelineRun, if none is specified.
+    default-timeout-minutes: "60"  # 60 minutes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-aggregate-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - tasks
+  - taskruns
+  - pipelines
+  - pipelineruns
+  - pipelineresources
+  - conditions
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2019 Tekton Authors LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: tekton-pipelines-controller
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+spec:
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: tekton-pipelines-controller
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Task
+    plural: tasks
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: conditions.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Condition
+    plural: conditions
+    categories:
+      - all
+      - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: webhook-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-webhook
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: webhook-controller
+    spec:
+      serviceAccountName: tekton-pipelines-controller
+      containers:
+      - name: webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image:  quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v
+        volumeMounts:
+        - name: config-logging
+          mountPath: /etc/config-logging
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-pvc
+  namespace: tekton-pipelines
+data:
+  # size of the PVC volume
+  # size: 5Gi
+
+  # storage class of the PVC volume
+  # storageClassName: storage-class-name
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: TaskRun
+    plural: taskruns
+    categories:
+    - all
+    - tekton-pipelines
+    shortNames:
+    - tr
+    - trs
+  scope: Namespaced
+  additionalPrinterColumns:
+  - name: Succeeded
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+  - name: StartTime
+    type: date
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    JSONPath: .status.completionTime
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-artifact-bucket
+  namespace: tekton-pipelines
+data:
+  # location of the gcs bucket to be used for artifact storage
+  # location: "gs://bucket-name"
+
+  # name of the secret that will contain the credentials for the service account
+  # with access to the bucket
+  # bucket.service.account.secret.name:
+
+  # The key in the secret with the required service account json
+  # bucket.service.account.secret.key:
+
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-pipelines-controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-pipelines-controller
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: controller
+    spec:
+      serviceAccountName: tekton-pipelines-controller
+      containers:
+      - name: tekton-pipelines-controller
+        image:  quay.io/openshift-pipeline/tektoncd-pipeline-controller:v
+        args: [
+          "-logtostderr",
+          "-stderrthreshold", "INFO",
+          "-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v",
+          "-creds-image", "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v",
+          "-git-image", "quay.io/openshift-pipeline/tektoncd-pipeline-git-init:v",
+          "-nop-image", "quay.io/openshift-pipeline/tektoncd-pipeline-nop:v",
+          "-bash-noop-image", "quay.io/openshift-pipeline/tektoncd-pipeline-bash:v",
+          "-gsutil-image","quay.io/openshift-pipeline/tektoncd-pipeline-gsutil:v",
+          "-entrypoint-image", "quay.io/openshift-pipeline/tektoncd-pipeline-entrypoint:v",
+          "-imagedigest-exporter-image", "quay.io/openshift-pipeline/tektoncd-pipeline-imagedigestexporter:v",
+          "-pr-image", "quay.io/openshift-pipeline/tektoncd-pipeline-pullrequest-init:v",
+          "-build-gcs-fetcher-image", "github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher",
+        ]
+        volumeMounts:
+        - name: config-logging
+          mountPath: /etc/config-logging
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: tekton.dev/pipeline
+      volumes:
+        - name: config-logging
+          configMap:
+            name: config-logging
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: ClusterTask
+    plural: clustertasks
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Cluster
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+# Copyright 2019 Tekton Authors LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: tekton-pipelines
+data:
+  # Common configuration for all knative codebase
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+
+  # Log level overrides
+  loglevel.controller: "info"
+  loglevel.webhook: "info"
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: tekton-pipelines
+
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using Stackdriver will incur additional charges.
+    metrics.backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used and metrics will be sent to the cluster's project if this field is
+    # not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
+    # to send metrics to Stackdriver using "global" resource type and custom
+    # metric type. Setting this flag to "true" could cause extra Stackdriver
+    # charge.  If metrics.backend-destination is not Stackdriver, this is
+    # ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: tekton-pipelines
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+  - 'emptyDir'
+  - 'configMap'
+  - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-controller-admin
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-pipelines-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: tekton-pipelines
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelines.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: Pipeline
+    plural: pipelines
+    categories:
+    - all
+    - tekton-pipelines
+  scope: Namespaced
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+
+---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineRun
+    plural: pipelineruns
+    categories:
+    - all
+    - tekton-pipelines
+    shortNames:
+    - pr
+    - prs
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      JSONPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      JSONPath: .status.completionTime
+  # Opt into the status subresource so metadata.generation
+  # starts to increment
+  subresources:
+    status: {}
+  version: v1alpha1
+

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Synchs the release-next branch to master and then triggers CI
+# Usage: update-to-head.sh
+
+set -e
+REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+
+# Reset release-next to upstream/master.
+git fetch upstream master
+git checkout upstream/master -B release-next
+
+# Update openshift's master and take all needed files from there.
+git fetch openshift master
+git checkout openshift/master openshift OWNERS_ALIASES OWNERS Makefile
+make generate-dockerfiles
+make RELEASE=ci generate-release
+git add openshift OWNERS_ALIASES OWNERS Makefile
+git commit -m ":open_file_folder: Update openshift specific files."
+git push -f openshift release-next
+
+# Trigger CI
+git checkout release-next -B release-next-ci
+date > ci
+git add ci
+git commit -m ":robot: Triggering CI on branch 'release-next' after synching to upstream/master"
+git push -f openshift release-next-ci
+
+if hash hub 2>/dev/null; then
+   hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
+else
+   echo "hub (https://github.com/github/hub) is not installed, so you'll need to create a PR manually."
+fi

--- a/openshift/resolve-yamls.sh
+++ b/openshift/resolve-yamls.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+TMP=$(mktemp /tmp/.mm.XXXXXX)
+clean() { rm -f ${TMP}; }
+trap clean EXIT
+
+# Take all yamls in $dir and generate a all in one yaml file with resolved registry image/tag
+function resolve_resources() {
+  local dir=$1
+  local resolved_file_name=$2
+  local ignores=$3
+  local registry_prefix=$4
+  local image_tag=${5}
+
+  # This would get only one set of truth from the Makefile for the image lists
+  #
+  # % grep "^CORE_IMAGES" Makefile
+  # CORE_IMAGES=./cmd/bash ./cmd/controller ./cmd/entrypoint ./cmd/gsutil ./cmd/kubeconfigwriter ./cmd/nop ./cmd/webhook ./cmd/imagedigestexporter
+  # CORE_IMAGES_WITH_GIT=./cmd/creds-init ./cmd/git-init
+  # to:
+  #  % grep '^CORE_IMAGES' Makefile|sed -e 's/.*=//' -e 's,./cmd/,,g'|tr -d '\n'|sed -e 's/ /|/g' -e 's/^/(/' -e 's/$/)\n/'
+  # (bash|controller|entrypoint|gsutil|kubeconfigwriter|nop|webhook|imagedigestexportercreds-init|git-init)
+  local image_regexp=$(grep '^CORE_IMAGES' $(git rev-parse --show-toplevel)/Makefile| \
+                           sed -e 's/.*=//' -e 's,./cmd/,,g'|tr '\n' ' '| \
+                           sed -e 's/ /|/g' -e 's/^/(/' -e 's/|$/)\n/')
+
+  >$resolved_file_name
+  for yaml in $(find $dir -name "*.yaml" | grep -vE $ignores); do
+    echo "---" >>$resolved_file_name
+    if [[ -n ${image_tag} ]];then
+        # This is a release format the output would look like this :
+        # quay.io/openshift-pipeline/tektoncd-pipeline-bash:$image_tag
+        sed -e "s%\(.* image: \)\(github.com\)\(.*\/\)\(.*\)%\1 ${registry_prefix}-\4:${image_tag}%" $yaml \
+            -r -e "s,github.com/tektoncd/pipeline/cmd/${image_regexp},${registry_prefix}-\1:${image_tag},g" \
+            > ${TMP}
+     else
+        # This is CI which get built directly to the user registry namespace i.e: $OPENSHIFT_BUILD_NAMESPACE
+        # The output would look like this :
+        # internal-registry:5000/usernamespace:tektoncd-pipeline-bash
+        #
+        # note: test image are images only used for testing not for releases
+        sed -e 's%\(.* image: \)\(github.com\)\(.*\/\)\(test\/\)\(.*\)%\1\2 \3\4test-\5%' $yaml \
+            -e "s%\(.* image: \)\(github.com\)\(.*\/\)\(.*\)%\1 ""$registry_prefix"'\:tektoncd-pipeline-\4%'  \
+            -re "s,github.com/tektoncd/pipeline/cmd/${image_regexp},${registry_prefix}:tektoncd-pipeline-\1,g" \
+            > ${TMP}
+    fi
+
+    # Adding the labels: openshift.io/cluster-monitoring on Namespace to add the cluster-monitoring
+    # See: https://docs.openshift.com/container-platform/4.1/logging/efk-logging-deploying.html
+    grep -q "kind: Namespace" ${TMP} && sed -i '/^metadata:/a \ \ labels:\n\ \ \ \ openshift.io/cluster-monitoring:\ \"true\"' ${TMP}
+
+    cat ${TMP} >> $resolved_file_name
+
+    echo >>$resolved_file_name
+  done
+}


### PR DESCRIPTION
Sidecar tests are failing on CI.
The tests fails when the nop images are involved.
The nop image built by CI uses `ubi` as the base image as it specified so
in the generated Dockerfile for nop image

In local testing I could observe that the sidecar tests pass whe `scratch` is used
as the base image for nop. Upstream also seems to be using scratch as their base image for `nop` image

Hence, the purpiose of this patch to test whether changing the nop image base to `scratch` will make the sidecar test pass on ci