### PR TITLE
Use upstream nop image to fix sidecar tests.

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -35,6 +35,13 @@ function install_tekton_pipeline() {
 
 function create_pipeline() {
   resolve_resources config/ tekton-pipeline-resolved.yaml "nothing" $OPENSHIFT_REGISTRY/$OPENSHIFT_BUILD_NAMESPACE/stable
+
+  # NOTE(chmou): This is a very cheeky hack, sidecar is currently broken with
+  # our nop image so we just use nightly `nop` from upstream CI. `nop` should
+  # not change or do anything differently with a different base so we should be
+  # safe until https://github.com/tektoncd/pipeline/issues/1347 gets fixed
+  sed -i 's%"-nop-image.*%"-nop-image", "gcr.io/tekton-nightly/github.com/tektoncd/pipeline/cmd/nop:latest",%' tekton-pipeline-resolved.yaml
+
   oc apply -f tekton-pipeline-resolved.yaml
 }
 

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -10,7 +10,7 @@ readonly OPENSHIFT_REGISTRY="${OPENSHIFT_REGISTRY:-"registry.svc.ci.openshift.or
 readonly TEST_NAMESPACE=tekton-pipeline-tests
 readonly TEST_YAML_NAMESPACE=tekton-pipeline-tests-yaml
 readonly TEKTON_PIPELINE_NAMESPACE=tekton-pipelines
-readonly IGNORES="pipelinerun.yaml|private-taskrun.yaml|taskrun.yaml|gcs-resource-spec-taskrun.yaml"
+readonly IGNORES="pipelinerun.yaml|private-taskrun.yaml|taskrun.yaml|gcs|taskrun-git-volume.yaml"
 readonly KO_DOCKER_REPO=image-registry.openshift-image-registry.svc:5000/tektoncd-pipeline
 # Where the CRD will install the pipelines
 readonly TEKTON_NAMESPACE=tekton-pipelines
@@ -19,7 +19,9 @@ readonly OPENSHIFT_BUILD_NAMESPACE=${OPENSHIFT_BUILD_NAMESPACE:-tektoncd-build-$
 # Yaml test skipped due of not being able to run on openshift CI, usually becaus
 # of rights.
 # test-git-volume: `"gitRepo": gitRepo volumes are not allowed to be used]'
-declare -ar SKIP_YAML_TEST=(test-git-volume)
+# dind-sidecar-taskrun-1: securityContext.privileged: Invalid value: true: Privileged containers are not allowed]
+# gcs: google container storage
+declare -ar SKIP_YAML_TEST=(test-git-volume dind-sidecar-taskrun-1 build-gcs-targz build-gcs-zip gcs-resource)
 
 function install_tekton_pipeline() {
   header "Installing Tekton Pipeline"


### PR DESCRIPTION
Hack to get the TestSidecar working.

Full on discussion here (RH Only): https://coreos.slack.com/archives/CG5GV6CJD/p1568983413242300

We need to get https://github.com/tektoncd/pipeline/issues/1347 fixed to remove this hack.

```TODO```: rewrite e2e test and resolve_resource shell script in something else (python?), it becomes way too much spagethini-shelly and too much error prone 🍝