### PR TITLE
Fixes for CI Breakage due to upstream example modifications

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -10,7 +10,7 @@ readonly OPENSHIFT_REGISTRY="${OPENSHIFT_REGISTRY:-"registry.svc.ci.openshift.or
 readonly TEST_NAMESPACE=tekton-pipeline-tests
 readonly TEST_YAML_NAMESPACE=tekton-pipeline-tests-yaml
 readonly TEKTON_PIPELINE_NAMESPACE=tekton-pipelines
-readonly IGNORES="pipelinerun.yaml|private-taskrun.yaml|taskrun.yaml|gcs|taskrun-git-volume.yaml"
+readonly IGNORES="pipelinerun.yaml|pull-private-image.yaml|build-push-kaniko.yaml|gcs|git-volume.yaml"
 readonly KO_DOCKER_REPO=image-registry.openshift-image-registry.svc:5000/tektoncd-pipeline
 # Where the CRD will install the pipelines
 readonly TEKTON_NAMESPACE=tekton-pipelines
@@ -173,7 +173,9 @@ function delete_build_pipeline_openshift() {
 
 function delete_test_resources_openshift() {
   echo ">> Removing test resources (test/)"
-  oc delete --ignore-not-found=true -f tests-resolved.yaml
+  # ignore any errors while deleting tests-resolved.yaml
+  # some of the resources use `GenerateName` instead of `Name`
+  oc delete --ignore-not-found=true -f tests-resolved.yaml || true
 }
 
 function delete_test_namespace() {


### PR DESCRIPTION
Update `IGNORES` var in test script w.r.t upstream file renaming
Replaces
-readonly IGNORES="pipelinerun.yaml|private-taskrun.yaml|taskrun.yaml|gcs|taskrun-git-volume.yaml"
+readonly IGNORES="pipelinerun.yaml|pull-private-image.yaml|build-push-kaniko.yaml|gcs|git-volume.yaml"

Update e2e-tests-openshift.sh to ignore errors from `delete_test_resources_openshift`

as the following file renaming was done upstream:
```
examples/taskruns/taskrun.yaml → examples/taskruns/build-push-kaniko.yaml
examples/taskruns/taskrun-git-volume.yaml → examples/taskruns/git-volume.yaml
examples/taskruns/private-taskrun.yaml → examples/taskruns/pull-private-image.yaml
```

other changes in upstream in the patch that changed the file names
ref: https://github.com/tektoncd/pipeline/commit/3873c3ce5223f54cdd097215ebf71d10aebd7c37
```
renames (added to IGNORE var in downstream test)

examples/taskruns/taskrun.yaml → examples/taskruns/build-push-kaniko.yaml 
examples/taskruns/taskrun-git-volume.yaml → examples/taskruns/git-volume.yaml
examples/taskruns/private-taskrun.yaml → examples/taskruns/pull-private-image.yaml

other renames
examples/taskruns/taskrun-configmap.yaml → examples/taskruns/configmap.yaml
examples/taskruns/taskrun-custom-env.yaml → examples/taskruns/custom-env.yaml
examples/taskruns/taskrun-custom-volume.yaml → examples/taskruns/custom-volume.yaml
examples/taskruns/task-sidecar-dind.yaml → examples/taskruns/dind-sidecar.yaml
examples/taskruns/taskrun-docker-basic.yaml → examples/taskruns/docker-creds.yaml
examples/taskruns/taskrun-git-ssh.yaml → examples/taskruns/git-ssh-creds.yaml
examples/taskruns/taskrun-home.yaml → examples/taskruns/home-is-set.yaml
examples/taskruns/taskrun-home-volume.yaml → examples/taskruns/home-volume.yaml
examples/taskruns/taskrun-secret-env.yaml → examples/taskruns/secret-env.yaml
examples/taskruns/taskrun-order.yaml → examples/taskruns/steps-run-in-order.yaml
examples/taskruns/taskrun-unnamed-steps.yaml → examples/taskruns/unnamed-steps.yaml
examples/taskruns/taskrun-workindir.yaml → examples/taskruns/workingdir.yaml
examples/taskruns/taskrun-workspace.yaml → examples/taskruns/workspace-volume.yaml

new
examples/taskruns/clustertask.yaml
examples/taskruns/git-resource.yaml
examples/taskruns/pullrequest.yaml
examples/taskruns/secret-volume-params.yaml 
examples/taskruns/secret-volume.yaml
examples/taskruns/steptemplate-env-merge.yaml
examples/taskruns/template-volume.yaml

deleted
git-resource-spec-taskrun.yaml
examples/taskruns/task-env.yaml
examples/taskruns/task-volume.yaml
examples/taskruns/taskrun-cluster-task.yaml
examples/taskruns/taskrun-git-source.yaml
examples/taskruns/taskrun-github-pr.yaml
examples/taskruns/taskrun-secret-volume.yaml
examples/taskruns/taskrun-volume-secret-args.yaml

```

