### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile.in openshift/ci-operator/knative-images $(CORE_IMAGES)
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile-git.in openshift/ci-operator/knative-images $(CORE_IMAGES_WITH_GIT)
 	@echo "There is some custom images that are only updated manually in:"; \
-	echo "	$(CORE_IMAGES_CUSTOMED)";\
+	echo "	$(CORE_IMAGES_CUSTOMED)";
 .PHONY: generate-dockerfiles
 
 # NOTE(chmou): Install uidwraper for launching some binaries with fixed uid


### PR DESCRIPTION
Remove extra `\` character in `generate-dockerfiles` target
which was causing the target to fail
`.PHONY:: command not found` error

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>