### PR TITLE
Improve resolve-yamls.sh

### DIFF
--- a/openshift/resolve-yamls.sh
+++ b/openshift/resolve-yamls.sh
@@ -24,7 +24,7 @@ function resolve_resources() {
                            sed -e 's/ /|/g' -e 's/^/(/' -e 's/|$/)\n/')
 
   >$resolved_file_name
-  for yaml in $(find $dir -name "*.yaml" | grep -vE $ignores); do
+  for yaml in $(find $dir -name "*.yaml" | grep -vE $ignores | sort); do
     echo "---" >>$resolved_file_name
     if [[ -n ${image_tag} ]];then
         # This is a release format the output would look like this :


### PR DESCRIPTION
Add a sort to the `find $dir -name "*.yaml" | grep -vE $ignores | sort`

This patch will make sure that the yamls are resolved
in the order (numbered names) specified in config dir

# Before
`for yaml in $(find config -name "*.yaml" | grep -vE noignores); do`
```
config/webhook.yaml
config/config-observability.yaml
config/controller.yaml
config/300-task.yaml
...
```

# After
`for yaml in $(find config -name "*.yaml" | grep -vE noignores | sort); do`
```
config/100-namespace.yaml
config/101-podsecuritypolicy.yaml
config/200-clusterrole.yaml
config/200-serviceaccount.yaml
config/201-clusterrolebinding.yaml
config/300-clustertask.yaml
...
```

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>