### PR TITLE
Add mechanism to build/tag gcs-fetcher image which is used by tekton-controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ CGO_ENABLED=0
 GOOS=linux
 CORE_IMAGES=./cmd/bash ./cmd/controller ./cmd/entrypoint ./cmd/gsutil ./cmd/kubeconfigwriter ./cmd/webhook ./cmd/imagedigestexporter ./cmd/pullrequest-init
 CORE_IMAGES_WITH_GIT=./cmd/creds-init ./cmd/git-init
+ADDN_IMAGES=./vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher
 # For the custom ones that are not auto generated
 CORE_IMAGES_CUSTOMED=./cmd/nop
 
-ALL_IMAGES=$(CORE_IMAGES) $(CORE_IMAGES_CUSTOMED) $(CORE_IMAGES_WITH_GIT)
+ALL_IMAGES=$(CORE_IMAGES) $(CORE_IMAGES_WITH_GIT) $(ADDN_IMAGES) $(CORE_IMAGES_CUSTOMED)
 
 ##
 # You need to provide a RELEASE_VERSION when using targets like `push-image`, you can do it directly
@@ -50,6 +51,7 @@ check-images:
 # Generate Dockerfiles used by ci-operator. The files need to be committed manually.
 generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile.in openshift/ci-operator/knative-images $(CORE_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile.in openshift/ci-operator/knative-images $(ADDN_IMAGES)
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/Dockerfile-git.in openshift/ci-operator/knative-images $(CORE_IMAGES_WITH_GIT)
 	@echo "There is some custom images that are only updated manually in:"; \
 	echo "	$(CORE_IMAGES_CUSTOMED)";

--- a/openshift/ci-operator/knative-images/gcs-fetcher/Dockerfile
+++ b/openshift/ci-operator/knative-images/gcs-fetcher/Dockerfile
@@ -1,0 +1,5 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ADD gcs-fetcher /ko-app/gcs-fetcher
+ENTRYPOINT ["/ko-app/gcs-fetcher"]

--- a/openshift/resolve-yamls.sh
+++ b/openshift/resolve-yamls.sh
@@ -52,4 +52,11 @@ function resolve_resources() {
 
     echo >>$resolved_file_name
   done
+
+  # handle additional images which are not build from ./cmd (images not in $CORE_IMAGES)
+  if [[ -n ${image_tag} ]];then
+      sed -i -r -e "s,github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher,${registry_prefix}-gcs-fetcher:${image_tag},g" $resolved_file_name
+   else
+      sed -i -r -e "s,github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher,${registry_prefix}:tektoncd-pipeline-gcs-fetcher,g" $resolved_file_name
+  fi
 }


### PR DESCRIPTION
gcs-fetcher is no a binary from `./cmd`. It is an image which shoudl be built from a vendored
dependency `vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher`

This patch adds the mechanism to build `vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher`
in openshift-ci

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit dde7d4ea75104216565479c3937fee0d93ed04e2)