### PR TITLE
Add v0.7.0 release.yaml

### DIFF
--- a/openshift/release/tektoncd-pipeline-v0.7.0.yaml
+++ b/openshift/release/tektoncd-pipeline-v0.7.0.yaml
@@ -809,7 +809,7 @@ spec:
           "-entrypoint-image", "quay.io/openshift-pipeline/tektoncd-pipeline-entrypoint:v0.7.0",
           "-imagedigest-exporter-image", "quay.io/openshift-pipeline/tektoncd-pipeline-imagedigestexporter:v0.7.0",
           "-pr-image", "quay.io/openshift-pipeline/tektoncd-pipeline-pullrequest-init:v0.7.0",
-          "-build-gcs-fetcher-image", "github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher",
+          "-build-gcs-fetcher-image", "quay.io/openshift-pipeline/tektoncd-pipeline-gcs-fetcher:v0.7.0",
         ]
         volumeMounts:
         - name: config-logging


### PR DESCRIPTION
This pathc updates the v0.7.0 release.yaml with correct reference to `gcs-fetcher` image

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>