### PR TITLE
[CI-TEST] Adds OpenShift monitoring config

### DIFF
--- a/openshift/addons/pipeline-monitoring.yaml
+++ b/openshift/addons/pipeline-monitoring.yaml
@@ -1,0 +1,66 @@
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-pipelines-read
+  namespace: tekton-pipelines
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-pipelines-prometheus-k8s-read-binding
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-pipelines-read
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: controller
+  annotations:
+    networkoperator.openshift.io/ignore-errors: ""
+  name: openshift-pipelines-monitor
+  namespace: tekton-pipelines
+spec:
+  endpoints:
+    - interval: 10s
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - openshift-pipelines
+  selector:
+    matchLabels:
+      app: tekton-pipelines-controller

--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -34,8 +34,7 @@ function install_tekton_pipeline() {
 }
 
 function create_pipeline() {
-  resolve_resources config/ tekton-pipeline-resolved.yaml "nothing" $OPENSHIFT_REGISTRY/$OPENSHIFT_BUILD_NAMESPACE/stable
-
+  generate_pipeline_resources tekton-pipeline-resolved.yaml $OPENSHIFT_REGISTRY/$OPENSHIFT_BUILD_NAMESPACE/stable
   oc apply -f tekton-pipeline-resolved.yaml
 }
 

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -13,4 +13,4 @@ else
     tag=$release
 fi
 
-resolve_resources config/ $output_file noignore $image_prefix $tag
+generate_pipeline_resources $output_file $image_prefix $tag

--- a/openshift/resolve-yamls.sh
+++ b/openshift/resolve-yamls.sh
@@ -60,3 +60,17 @@ function resolve_resources() {
       sed -i -r -e "s,github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher,${registry_prefix}:tektoncd-pipeline-gcs-fetcher,g" $resolved_file_name
   fi
 }
+
+function generate_pipeline_resources() {
+    local output_file=$1
+    local image_prefix=$2
+    local image_tag=$3
+
+    resolve_resources config/ $output_file noignore $image_prefix $image_tag
+
+    # Appends addon configs such as prometheus monitoring config
+    for yaml in $(find openshift/addons/ -name "*.yaml" | sort); do
+      echo "---" >> $output_file
+      cat ${yaml} >> $output_file
+    done
+}


### PR DESCRIPTION
In order to enable cluster-monitoring prometheus
to scrape the openshift pipeline metrics it requires
certain configuration such as "ServiceMonitor" and
list "pods, service etc" roles/rolebinding. This configuration can be
done through operator but it would create additional segway
and increase delta between upstream and downstream operator.

Instead, this patch alters `generate-release.yaml` to append
above mentioned configuration in `release.yaml`.