### PR TITLE
Bump go version to 1.12

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.10
+FROM openshift/origin-release:golang-1.13
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
This will bump the go version from 1.10
to 1.12 as the upstream has used feature
like strings.ReplaceAll() which got available
from 1.12