### PR TITLE
Add disable_gcp build tag to make it run on GCP 🏃

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ REGISTRY_RELEASE_URL=quay.io/openshift-pipeline/tektoncd-pipeline
 
 # Install core images
 install: installuidwrapper
-	@env CGO_ENABLED=0 go install $(ALL_IMAGES)
+	@env CGO_ENABLED=0 go -tags="disable_gcp" install $(ALL_IMAGES)
 .PHONY: install
 
 # Run E2E tests on OpenShift


### PR DESCRIPTION
Now that master has the upstream "fix"
https://github.com/tektoncd/pipeline/commit/530f0843732f4db6de3597571710c501a923c320,
we can use this build tag to disable the GCP credentialprovider and
make OpenShift Pipeline work on GCP.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>