### PR TITLE
fix skip tests

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -49,7 +49,8 @@ function create_test_namespace() {
 
 function run_go_e2e_tests() {
   header "Running Go e2e tests"
-  go test -v -failfast -count=1 -tags=e2e -ldflags '-X github.com/tektoncd/pipeline/test.missingKoFatal=false -X github.com/tektoncd/pipeline/test.skipRootUserTests=true' ./test -timeout=20m --kubeconfig $KUBECONFIG || return 1
+  go test -v -failfast -count=1 -tags=e2e -ldflags '-X github.com/tektoncd/pipeline/test.missingKoFatal=false' ./test -skipRootUserTests=true -timeout=20m --kubeconfig $KUBECONFIG || return 1
+  go test -v -failfast -count=1 -tags=e2e -ldflags '-X github.com/tektoncd/pipeline/test/v1alpha1.missingKoFatal=false' ./test/v1alpha1 -skipRootUserTests=true -timeout=20m --kubeconfig $KUBECONFIG || return 1
 }
 
 function run_yaml_e2e_tests() {


### PR DESCRIPTION
Modifies openshift/e2e-tests-openshift.sh with appropriate flags to skip RootUser Tests

Related to: https://github.com/tektoncd/pipeline/pull/2304
and https://github.com/openshift/tektoncd-pipeline/pull/364
changes in #2304 will not be available in upstream rc3, hence it is separately added in midstream rc3 branch through #364 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
(cherry picked from commit d728e507307460d73d0386c6cb0d983d764c39a2)
Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>