### PR TITLE
Fix ServiceMonitor endpoint

### DIFF
--- a/openshift/addons/pipeline-monitoring.yaml
+++ b/openshift/addons/pipeline-monitoring.yaml
@@ -55,11 +55,12 @@ metadata:
   namespace: tekton-pipelines
 spec:
   endpoints:
-    - interval: 10s
-      port: metrics
+  - interval: 10s
+    port: http-metrics
+  jobLabel: app
   namespaceSelector:
     matchNames:
-      - openshift-pipelines
+    - openshift-pipelines
   selector:
     matchLabels:
       app: tekton-pipelines-controller

--- a/openshift/release/tektoncd-pipeline-v0.13.2.yaml
+++ b/openshift/release/tektoncd-pipeline-v0.13.2.yaml
@@ -1687,11 +1687,12 @@ metadata:
   namespace: tekton-pipelines
 spec:
   endpoints:
-    - interval: 10s
-      port: metrics
+  - interval: 10s
+    port: http-metrics
+  jobLabel: app
   namespaceSelector:
     matchNames:
-      - openshift-pipelines
+    - openshift-pipelines
   selector:
     matchLabels:
       app: tekton-pipelines-controller


### PR DESCRIPTION
The service name of tekton pipeline controller is http-metrics. The file has metrics. This patch fixes it.