### PR TITLE
Add a BreakPoint mechanism in test script

### DIFF
--- a/openshift/e2e-tests-openshift.sh
+++ b/openshift/e2e-tests-openshift.sh
@@ -186,6 +186,26 @@ function teardown() {
   delete_build_pipeline_openshift
 }
 
+# usage:
+#    create a breakpoint by adding
+#    ```
+#    breakPoint <breakPointName>
+#    ```
+#
+#    to resume (run in pod `e2e`, container `test`)
+#    ```
+#    touch <breakPointName>
+#    ```
+function breakPoint() {
+  waitFileName=${1:-waitFile}
+  while [[ ! -f ${waitFileName} ]]; do
+    sleep 10;
+    echo \*\* --------------------------------------- \*\*
+    echo \*\* breakPoint                              \*\*;
+    echo \*\* run \`touch ${waitFileName}\` to resume \*\*
+  done
+}
+
 create_test_namespace
 
 ## If we want to debug the E2E script we don't want to use the images from the


### PR DESCRIPTION
Add a `while [[ ! -f ${waitFileName} ]];` based breakPoint mechanism (func)
to e2e-test script.

This will be useful when we want to make ci-debug prs and want control the test flow on ci.

This give better control and predictability compared to a `sleep <duration>` command.

**usage:**
create a breakpoint by adding
```
breakPoint <breakPointName>
```

to resume (run in pod `e2e`, container `test`)
```
touch <breakPointName>
```

note: breakPointName is a fileName. The breakPoint function waits until the file is created.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>