### PR TITLE
Fix ServiceMonitor endpoint

### DIFF
--- a/openshift/addons/pipeline-monitoring.yaml
+++ b/openshift/addons/pipeline-monitoring.yaml
@@ -56,7 +56,7 @@ metadata:
 spec:
   endpoints:
   - interval: 10s
-    port: metrics
+    port: http-metrics
   jobLabel: app
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
The service name of tekton pipeline controller is http-metrics. The file has metrics. This patch fixes it.