### PR TITLE
No need to set runasUser in openshift release.yaml

### DIFF
--- a/openshift/resolve-yamls.sh
+++ b/openshift/resolve-yamls.sh
@@ -58,6 +58,9 @@ function resolve_resources() {
              > ${TMP}
     fi
 
+	# Remove runAsUser: id, openshift takes care of randoming them and we dont need a fixed uid for that 
+	sed -i '/runAsUser: [0-9]*/d' ${TMP}
+
     # Adding the labels: openshift.io/cluster-monitoring on Namespace to add the cluster-monitoring
     # See: https://docs.openshift.com/container-platform/4.1/logging/efk-logging-deploying.html
     grep -qzP "kind: Namespace\nmetadata:\n\ \ name:\ tekton-pipelines" ${TMP} && sed -i '/^\ \ labels:/a \ \ \ \ openshift.io/cluster-monitoring:\ \"true\"' ${TMP}


### PR DESCRIPTION
since openshift takes care of th uid randomization and not allowing to set a fix
uuid under 1000620000

The error:

```40s         Warning   FailedCreate
replicaset/tekton-pipelines-webhook-55b98d698      Error creating: pods
"tekton-pipelines-webhook-55b98d698-" is forbidden: unable to validate against
any security context constraint:
[spec.containers[0].securityContext.securityContext.runAsUser: Invalid value:
1001: must be in the ranges: [1000620000, 1000629999]]```