### PR TITLE
Regenerate openshift patches

### DIFF
--- a/openshift/patches/0001-Remove-TestTaskRunRetry-too-much-flakyness.patch
+++ b/openshift/patches/0001-Remove-TestTaskRunRetry-too-much-flakyness.patch
@@ -1,38 +1,24 @@
-From cd0c10a3a1eaae979121959146b439c9aa373e62 Mon Sep 17 00:00:00 2001
-From: Chmouel Boudjnah <chmouel@redhat.com>
-Date: Fri, 17 Apr 2020 08:48:19 +0200
-Subject: [PATCH] Remove TestTaskRunRetry, too much flakyness
-
-Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
----
- test/retry_test.go          | 1 +
- test/v1alpha1/retry_test.go | 1 +
- 2 files changed, 2 insertions(+)
-
 diff --git a/test/retry_test.go b/test/retry_test.go
-index cce0874b8..3169c2016 100644
+index ce6625d83..48bd910ef 100644
 --- a/test/retry_test.go
 +++ b/test/retry_test.go
-@@ -33,6 +33,7 @@ import (
- // TestTaskRunRetry tests that retries behave as expected, by creating multiple
- // Pods for the same TaskRun each time it fails, up to the configured max.
- func TestTaskRunRetry(t *testing.T) {
-+	t.Skip("Flaky")
- 	c, namespace := setup(t)
- 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
- 	defer tearDown(t, c, namespace)
-diff --git a/test/v1alpha1/retry_test.go b/test/v1alpha1/retry_test.go
-index ab7add104..a6116c6aa 100644
---- a/test/v1alpha1/retry_test.go
-+++ b/test/v1alpha1/retry_test.go
 @@ -34,6 +34,7 @@ import (
  // TestTaskRunRetry tests that retries behave as expected, by creating multiple
  // Pods for the same TaskRun each time it fails, up to the configured max.
  func TestTaskRunRetry(t *testing.T) {
++	t.Skip("Flaky)
+ 	ctx := context.Background()
+ 	ctx, cancel := context.WithCancel(ctx)
+ 	defer cancel()
+diff --git a/test/v1alpha1/retry_test.go b/test/v1alpha1/retry_test.go
+index 3f04ef633..7a1710be4 100644
+--- a/test/v1alpha1/retry_test.go
++++ b/test/v1alpha1/retry_test.go
+@@ -35,6 +35,7 @@ import (
+ // TestTaskRunRetry tests that retries behave as expected, by creating multiple
+ // Pods for the same TaskRun each time it fails, up to the configured max.
+ func TestTaskRunRetry(t *testing.T) {
 +	t.Skip("Flaky")
- 	c, namespace := setup(t)
- 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
- 	defer tearDown(t, c, namespace)
--- 
-2.25.0
-
+ 	ctx := context.Background()
+ 	ctx, cancel := context.WithCancel(ctx)
+ 	defer cancel()

--- a/openshift/patches/0001-Skip-duplications-tests.patch
+++ b/openshift/patches/0001-Skip-duplications-tests.patch
@@ -1,40 +1,24 @@
-From b64e5a7b7b9544d22946724b9a336385197ed517 Mon Sep 17 00:00:00 2001
-From: Chmouel Boudjnah <chmouel@redhat.com>
-Date: Tue, 31 Mar 2020 18:15:06 +0200
-Subject: [PATCH] Skip duplications tests
-
-They are flaky on OpenShift and runs most of the time in OOM.
-
-Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
----
- test/duplicate_test.go          | 1 +
- test/v1alpha1/duplicate_test.go | 1 +
- 2 files changed, 2 insertions(+)
-
 diff --git a/test/duplicate_test.go b/test/duplicate_test.go
-index fd19ba9d..c2e24272 100644
+index 70682860e..e551d9a24 100644
 --- a/test/duplicate_test.go
 +++ b/test/duplicate_test.go
+@@ -33,6 +33,7 @@ import (
+ 
+ // TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
+ func TestDuplicatePodTaskRun(t *testing.T) {
++	t.Skip("Too much memory used on OpenShift")
+ 	ctx := context.Background()
+ 	ctx, cancel := context.WithCancel(ctx)
+ 	defer cancel()
+diff --git a/test/v1alpha1/duplicate_test.go b/test/v1alpha1/duplicate_test.go
+index 19be6e7e7..24cd06167 100644
+--- a/test/v1alpha1/duplicate_test.go
++++ b/test/v1alpha1/duplicate_test.go
 @@ -32,6 +32,7 @@ import (
  
  // TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
  func TestDuplicatePodTaskRun(t *testing.T) {
-+	t.Skip("This consumes too much memory on openshift and is buggy")
- 	c, namespace := setup(t)
- 	t.Parallel()
- 
-diff --git a/test/v1alpha1/duplicate_test.go b/test/v1alpha1/duplicate_test.go
-index 083dbf5c..b302191a 100644
---- a/test/v1alpha1/duplicate_test.go
-+++ b/test/v1alpha1/duplicate_test.go
-@@ -31,6 +31,7 @@ import (
- 
- // TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
- func TestDuplicatePodTaskRun(t *testing.T) {
-+	t.Skip("This consumes too much memory on openshift and is buggy")
- 	c, namespace := setup(t)
- 	t.Parallel()
- 
--- 
-2.25.0
-
++	t.Skip("Too much memory used on OpenShift")
+ 	ctx := context.Background()
+ 	ctx, cancel := context.WithCancel(ctx)
+ 	defer cancel()


### PR DESCRIPTION
We update patches that are flaky on OpenShift.

Due of the move to latest client-go which add context everywhere, we have to
refresh the patches.