### PR TITLE
Move away from Docker Hub due to rate limiting

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM openshift/origin-release:golang-1.14
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
This commit changes the image `openshift/origin-release:golang-1.14`
(which is hosted on Docker Hub) to
`registry.svc.ci.openshift.org/openshift/release:golang-1.14` which is
a public repository as well. The main motivation being the CI failures
occurring due to Docker Hub's rate limiting.