### PR TITLE
Update registry URL from registry.svc.ci.openshift.org to registry.ci.openshift.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ALL_IMAGES=$(CORE_IMAGES) $(CORE_IMAGES_WITH_GIT) $(CORE_IMAGES_CUSTOMED)
 # You need to provide a RELEASE_VERSION when using targets like `push-image`, you can do it directly
 # on the command like this: `make push-image RELEASE_VERSION=0.4.0`
 RELEASE_VERSION=
-REGISTRY_CI_URL=registry.svc.ci.openshift.org/openshift/tektoncd-v$(RELEASE_VERSION):tektoncd-pipeline
+REGISTRY_CI_URL=registry.ci.openshift.org/openshift/tektoncd-v$(RELEASE_VERSION):tektoncd-pipeline
 REGISTRY_RELEASE_URL=quay.io/openshift-pipeline/tektoncd-pipeline
 
 # Install core images

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14
+FROM registry.ci.openshift.org/openshift/release:golang-1.14
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/openshift/resolve-yamls.sh
+++ b/openshift/resolve-yamls.sh
@@ -69,7 +69,7 @@ function resolve_resources() {
 
     # Fix to ill formated images
     # dynamically get the Build image reference on each pr's before running yaml tests
-    # Eg: gcr.io/tekton-releases/registry.svc.ci.openshift.org/ci-op-qy1fnwv7/stable:tektoncd-pipeline-git-init:v0.11.3 --> registry.svc.ci.openshift.org/ci-op-qy1fnwv7/stable:tektoncd-pipeline-git-init
+    # Eg: gcr.io/tekton-releases/registry.ci.openshift.org/ci-op-qy1fnwv7/stable:tektoncd-pipeline-git-init:v0.11.3 --> registry.ci.openshift.org/ci-op-qy1fnwv7/stable:tektoncd-pipeline-git-init
     sed -i -r -e "s,gcr.io/tekton-releases/${registry_prefix}:tektoncd-pipeline-${image_regexp}(.*),${registry_prefix}:tektoncd-pipeline-\1,g" $resolved_file_name
 
     echo >>$resolved_file_name


### PR DESCRIPTION
There is change in registry address and because of the [CI](https://github.com/openshift/tektoncd-pipeline/pull/635) failing

As part of this PR updating registry url.

/cc @piyush-garg @praveen4g0 @vdemeester 